### PR TITLE
Fix issues with `calculate_c3_assimilation`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -31,6 +31,12 @@ for the next release.
   and an option for using it in the `gm_from_tdl` script.
 - Modified Licor-TDL pairing to stop assuming a particular relationship between
   the sample and reference valve numbers.
+- Fixed an issue with `calculate_c3_assimilation` that was causing it to report
+  incorrect `An` values at low `Cc`.
+- Fixed several typos where `Ac` was misidentified as the "RuBP-limited" rate;
+  in fact, it is the RuBP-saturated rate but is more commonly referred to as the
+  rubisco-limited rate.
+- Added a new example script that uses `fit_c3_aci`.
 
 # PhotoGEA VERSION 0.4.0 (2022-09-07)
 

--- a/man/calculate_c3_assimilation.Rd
+++ b/man/calculate_c3_assimilation.Rd
@@ -135,13 +135,13 @@
 \details{
   This function follows Chapter 2 from S. von Caemmerer's textbook, referenced
   above. In this model, the net CO2 assimilation rate \code{An} is given by the
-  smaller of the RuBP-regeneration-limited rate \code{Ac}, the
-  electron-transport-limited rate \code{Aj}, and the phosphate-limited rate
-  \code{Ap}, as expressed by Equation 2.27:
+  smaller of the rubisco-limited rate \code{Ac}, the electron-transport-limited
+  rate \code{Aj}, and the phosphate-limited rate \code{Ap}, as expressed by
+  Equation 2.27:
 
   \code{An = min(Ac, Aj, Ap)}
 
-  The RuBP-regeneration-limited rate is calculated using Equation 2.20:
+  The rubisco-regeneration-limited rate is calculated using Equation 2.20:
 
   \code{Ac = (PCc - Gamma_star) * Vcmax_tl / (PCc + Kc * (1.0 + POc / Ko)) - Rd_tl}
 

--- a/vignettes/PhotoGEA.Rmd
+++ b/vignettes/PhotoGEA.Rmd
@@ -141,8 +141,8 @@ Having fit the response curves, it is also possible to view the fits and the
 extracted parameters. For example, we can plot the measured values of net
 assimilation (`A`), the fitted values of net assimilation (`A_fit`), and each of
 the limiting assimilation rates calculated during the fitting procedure: the
-RuBP-regeneration-limited rate (`Ac`), the electron-transport-limited rate
-(`Aj`), and the phosphate-limited rate (`Ap`).
+rubisco-limited rate (`Ac`), the electron-transport-limited rate (`Aj`), and the
+phosphate-limited rate (`Ap`).
 
 ```{r}
 lattice::xyplot(

--- a/vignettes/analyzing_c3_aci_curves.Rmd
+++ b/vignettes/analyzing_c3_aci_curves.Rmd
@@ -62,7 +62,7 @@ Overall, the photosynthetic response to CO~2~ under high light conditions can be
 divided into three separate ranges:
 
 - At low levels of CO~2~ in the chloroplast, CO~2~ assimilation is primarily
-  limited by RuBP regeneration.
+  limited by rubisco activity.
 - At intermediate levels of CO~2~ in the chloroplast, CO~2~ assimilation is
   primarily limited by the electron transport rate.
 - At high levels of CO~2~ in the chloroplast, CO~2~ assimilation is primarily
@@ -72,7 +72,7 @@ More specifically, the model provides equations that separately describe the
 responses of three separate assimilation rates to the chloroplastic CO~2~
 concentration:
 
-- The RuBP-limited net CO~2~ assimilation rate ($A_c$).
+- The rubisco-limited net CO~2~ assimilation rate ($A_c$).
 - The electron-transport-limited rate ($A_j$).
 - The phosphate-limited rate ($A_p$).
 
@@ -661,8 +661,8 @@ determined by the `TPU` parameter; for some of the curves, the assimilation rate
 is never limited by `Ap`, so the resulting "best-fit" values of `TPU` may not be
 meaningful for these curves.
 
-There is also one curve (`ripe1 - tobacco - 2`) that does not follow the
-expected progression from RuBP-limited assimilation to
+There is also one curve (`ripe2 - tobacco - 4`) that does not follow the
+expected progression from rubisco-limited assimilation to
 electron-transport-limited assimilation as `Cc` increases; this entire fit may
 be unreliable, even if `A_fit` closely matches `A`. It is possible to force the
 optimizer to only allow fits where `Ac` is less than `Ap` below a certain
@@ -676,19 +676,19 @@ c3_aci_results <- consolidate(by(
   licor_data[, 'curve_identifier'], # A factor used to split `licor_data` into chunks
   fit_c3_aci,                       # The function to apply to each chunk of `licor_data`
   min_aj_cutoff = 100,              # Aj must be > Ac when Cc < 100 ppm
-  max_aj_cutoff = 800               # Aj must be < Ac when Cc > 800 ppm
+  max_aj_cutoff = 550               # Aj must be < Ac when Cc > 550 ppm
 ))
 
 <<fit_aci_limiting>>
 ```
 
-Here we can see an improvement in the fit for `ripe1 - tobacco - 2`. The fit for
+Here we can see an improvement in the fit for `ripe2 - tobacco - 4`. The fit for
 `ripe1 - soybean - 5a` is a little strange, but based on the values of `Ci` and
 `Cc`, it seems that this plant's stomata did not fully open during the
-measurement, restricting the measured assimilation values to the RuBP-limited
-range; there is nothing that can be done about this. It is also apparent that
-the `TPU` issue remains; again, there is nothing that can really be done to
-address it besides measuring more A-Ci curves.
+measurement, almost fully restricting the measured assimilation values to the
+rubisco-limited range; there is nothing that can be done about this. It is also
+apparent that the `TPU` issue remains; again, there is nothing that can really
+be done to address it besides measuring more A-Ci curves.
 
 # Examining the Results
 
@@ -704,7 +704,7 @@ the following example showing the fitted values of `Vcmax`:
 barchart_with_errorbars(
   c3_aci_results$parameters[, 'Vcmax_at_25'],
   c3_aci_results$parameters[, 'species'],
-  ylim = c(0, 150),
+  ylim = c(0, 180),
   xlab = 'Species',
   ylab = paste0('Vcmax at 25 degrees C (', c3_aci_results$parameters$units$Vcmax_at_25, ')')
 )
@@ -723,7 +723,7 @@ bwplot(
 )
 ```
 
-## Calculating Average Fit Parameters
+## Accessing Raw and Average Values of Fit Parameters
 
 We can also take a look at the raw numbers of the fitted parameters and their
 average values. The `c3_aci_results$parameters` object contains many columns but


### PR DESCRIPTION
Fixes an issue where `calculate_c3_assimilation` returned the wrong value for net assimilation at low values of chloroplast CO2 concentration