### PR TITLE
Provide option for fixing C3 parameters

### DIFF
--- a/R/calculate_c3_assimilation.R
+++ b/R/calculate_c3_assimilation.R
@@ -54,8 +54,8 @@ calculate_c3_assimilation <- function(
         check_required_variables(exdf_obj, required_variables)
 
         # Make sure the curvature value is acceptable
-        if (curvature < 0 || curvature > 1) {
-            stop('curvature must be between 0 and 1')
+        if (curvature <= 0 || curvature > 1) {
+            stop('curvature must be > 0 and <= 1')
         }
     }
 

--- a/man/calculate_c3_assimilation.Rd
+++ b/man/calculate_c3_assimilation.Rd
@@ -68,9 +68,9 @@
   }
 
   \item{curvature}{
-    A dimensionless quadratic curvature parameter between 0 and 1 that sets the
-    degree of co-limitation between \code{Ac}, \code{Aj}, and \code{Ap}. A value
-    of 1 indicates no co-limitation.
+    A dimensionless quadratic curvature parameter greater than 0 and less than
+    or equal to 1 that sets the degree of co-limitation between \code{Ac},
+    \code{Aj}, and \code{Ap}. A value of 1 indicates no co-limitation.
   }
 
   \item{cc_column_name}{

--- a/man/fit_c3_aci.Rd
+++ b/man/fit_c3_aci.Rd
@@ -47,9 +47,10 @@
     ),
     lower = c(0,  0,    0,   0),
     upper = c(40, 1000, 100, 1000),
+    fixed = c(40, NA,   NA,  NA),
     min_aj_cutoff = NA,
     max_aj_cutoff = NA,
-    curvature = 0.95
+    curvature = 0.97
   )
 }
 
@@ -145,6 +146,16 @@
     \code{J}, \code{Rd}, and \code{Vcmax}, in that order.
   }
 
+  \item{fixed}{
+    A numeric vector specifying fixed values of \code{TPU}, \code{J}, \code{Rd},
+    and \code{Vcmax}, in that order. Values of \code{NA} indicate that the
+    corresponding parameter is not fixed and should be varied during the
+    optimization procedure. The default value of this argument fixes \code{TPU}
+    to its upper limit (so net assimilation is never limited by phosphate
+    utilization) and allows the other parameters to vary. To vary all of the
+    parameters, set \code{fixed} to \code{c(NA, NA, NA, NA)}.
+  }
+
   \item{min_aj_cutoff}{
     The minimum value of \code{Cc} (in ppm) where \code{Aj} is allowed to become
     the overall rate-limiting factor. If \code{min_aj_cutoff} is set to
@@ -198,6 +209,12 @@
   following for the \code{initial_guess_fun}:
   \code{function(x){c(10, 100,  0.5, 90)}}, which would set the initial guess to
   \code{TPU = 10}, \code{J = 100}, \code{Rd = 0.5}, and \code{Vcmax = 90}.
+
+  By default, this function fixes \code{TPU} to a high value (\code{40 micromol
+  m^(-2) s^(-1)}) and allows the other parameters to be fitted. This behavior
+  is determined by the value of the \code{fixed} input argument, and the value
+  of \code{TPU} specified in this way will override any value returned by
+  \code{initial_guess_fun}.
 
   This function assumes that \code{replicate_exdf} represents a single
   C3 A-Ci curve. To fit multiple curves at once, this function is often used

--- a/vignettes/PhotoGEA.Rmd
+++ b/vignettes/PhotoGEA.Rmd
@@ -106,8 +106,7 @@ licor_data <- calculate_arrhenius(licor_data, c3_arrhenius_bernacchi)
 aci_results <- consolidate(by(
   licor_data,
   licor_data[, 'curve_id'],
-  fit_c3_aci,
-  max_aj_cutoff = 650
+  fit_c3_aci
 ))
 ```
 
@@ -142,12 +141,11 @@ Having fit the response curves, it is also possible to view the fits and the
 extracted parameters. For example, we can plot the measured values of net
 assimilation (`A`), the fitted values of net assimilation (`A_fit`), and each of
 the limiting assimilation rates calculated during the fitting procedure: the
-rubisco-limited rate (`Ac`), the electron-transport-limited rate (`Aj`), and the
-phosphate-limited rate (`Ap`).
+rubisco-limited rate (`Ac`) and the electron-transport-limited rate (`Aj`).
 
 ```{r}
 lattice::xyplot(
-  A + Ac + Aj + Ap + A_fit ~ Ci | curve_id,
+  A + Ac + Aj + A_fit ~ Ci | curve_id,
   data = aci_results$fits$main_data,
   type = 'l',
   auto.key = list(space = 'right'),

--- a/vignettes/analyzing_c3_aci_curves.Rmd
+++ b/vignettes/analyzing_c3_aci_curves.Rmd
@@ -130,7 +130,7 @@ xyplot(
   )
 )
 
-curvature <- 0.95
+curvature <- 0.97
 ```
 
 (Note: this figure was generated using the `c3_assimilation` function from
@@ -644,9 +644,17 @@ return the resulting parameters and fits:
 c3_aci_results <- consolidate(by(
   licor_data,                       # The `exdf` object containing the curves
   licor_data[, 'curve_identifier'], # A factor used to split `licor_data` into chunks
-  fit_c3_aci                        # The function to apply to each chunk of `licor_data`
+  fit_c3_aci,                       # The function to apply to each chunk of `licor_data`
+  fixed = c(NA, NA, NA, NA)         # Additional argument passed to `fit_c3_aci`
 ))
 ```
+
+Note that in this command, we specified `fixed = c(NA, NA, NA, NA)` when calling
+`fit_c3_aci`. By doing this, we are choosing to vary all four key photosynthetic
+parameters: `TPU`, `J`, `Rd`, and `Vcmax`. If `fixed` is not specified, it will
+take its default value: `c(Inf, NA, NA, NA)`. In that case, `TPU` would be fixed
+to a high value that essentially disables phosphate limited assimilation, and
+only `J`, `Rd`, and `Vcmax` would be varied.
 
 ## Viewing the Fitted Curves
 
@@ -713,6 +721,7 @@ c3_aci_results <- consolidate(by(
   licor_data,                       # The `exdf` object containing the curves
   licor_data[, 'curve_identifier'], # A factor used to split `licor_data` into chunks
   fit_c3_aci,                       # The function to apply to each chunk of `licor_data`
+  fixed = c(NA, NA, NA, NA),        # Additional argument passed to `fit_c3_aci`
   min_aj_cutoff = 100,              # Aj must be > Ac when Cc < 100 ppm
   max_aj_cutoff = 550               # Aj must be < Ac when Cc > 550 ppm
 ))
@@ -741,8 +750,7 @@ lattice::xyplot(
   pch = 16,
   grid = TRUE,
   xlab = paste0('Intercellular CO2 concentration (', aci_results$fits$units$Ci, ')'),
-  ylab = paste0('Assimilation rate residual (measured - fitted)\n(', aci_results$fits$units$A, ')'),
-  ylim = c(-10, 10)
+  ylab = paste0('Assimilation rate residual (measured - fitted)\n(', aci_results$fits$units$A, ')')
 )
 ```
 
@@ -864,6 +872,15 @@ arguments to `remove_points`. It might also not be necessary to remove the
 unstable points before performing the fits. Often, it is helpful to not perform
 any data cleaning at first, and then remove problematic points if they seem to
 cause problems with the fits.
+
+## TPU Limitations
+
+In this example, we consider phosphate utilization as a factor that may possibly
+limit assimilation. However, as discussed in [Fitting Licor Data], it is also
+possible to remove phosphate-limited assimilation from the model by fixing `TPU`
+to a high value and only fitting `J`, `Rd`, and `Vcmax`. Often it is wise to
+first try fitting a set of curves without `TPU` limitations, and only consider
+allowing `TPU` limitations if the resulting fits are not good.
 
 ## Averages and Standard Errors
 


### PR DESCRIPTION
This PR adds an option for fixing C3 parameters such as `TPU` or `Rd` instead of fitting them. The default for `fit_c3_aci` is now to fix `TPU` to a high value and only fit `J`, `Rd`, and `Vcmax`.