### PR TITLE
Update fit_c3_aci.R

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: PhotoGEA
-Version: 0.6.0
+Version: 0.6.1
 Title: Photosynthetic Gas Exchange Analysis
 Description: A collection of tools for loading and analyzing photosynthetic gas
     exchange data.

--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,14 @@ Subsequent commits will then include a new "Unreleased" section in preparation
 for the next release.
 -->
 
+# PhotoGEA VERSION 0.6.1 (2022-11-01)
+
+- Modified `fit_c3_aci` so it now ensures that the initial guess lies within
+  (and not on) the bounds. This is a requirement for the `dfoptim::nmkb` solver
+  and presumably other bounded optimizers as well.
+- PRs related to creating this version:
+  - https://github.com/eloch216/PhotoGEA/pull/57
+
 # PhotoGEA VERSION 0.6.0 (2022-10-06)
 
 - Moved the `dfoptim` package from `Suggests` to `Imports` because it is used by

--- a/R/fit_c3_aci.R
+++ b/R/fit_c3_aci.R
@@ -113,9 +113,12 @@ fit_c3_aci <- function(
     # Get an initial guess for all the parameter values
     initial_guess <- initial_guess_fun(replicate_exdf)
 
-    # Make sure the initial guess is acceptable
-    initial_guess <- pmax(initial_guess, lower)
-    initial_guess <- pmin(initial_guess, upper)
+    # Make sure the initial guess lies within (and not on) the bounds
+    lower_temp <- lower + 0.01 * (upper - lower)
+    upper_temp <- upper - 0.01 * (upper - lower)
+    
+    initial_guess <- pmax(initial_guess, lower_temp)
+    initial_guess <- pmin(initial_guess, upper_temp)
 
     # Find the best values for the parameters that should be varied
     optim_result <- OPTIM_FUN(


### PR DESCRIPTION
Previously, `fit_c3_aci` performed a check to ensure that the initial guess returned by `initial_guess_fun` lies within the lower and upper bounds supplied by the user (`lower` and `upper`, respectively):

```r
initial_guess <- pmax(initial_guess, lower)
initial_guess <- pmin(initial_guess, upper)
```

However, the `default_optimizer` uses the `dfoptim::nmkb` function, which requires that the initial guess lies within (but not on) the bounds. If the initial guess lies on the bounds, no error is produced, but the optimizer's behavior becomes undefined and it may begin making guesses of `NA` for some parameter values.

This can lead to some weird behavior. E.g. if there is a strange looking A-Ci curve, `initial_guess_c3_aci` may produce a negative estimate for `Rd`, which then gets reset by `fit_c3_aci` to the default lower bound of 0, which then causes an issue with the optimizer. Ultimately, an error will occur when a value of `Rd = NA` is passed to `calculate_c3_assimilation`. This whole process is very difficult to debug because the (uninformative) error message does not indicate that the real issue is related to the initial guess being on the bounds.

This PR addresses this problem by modifying `fit_c3_aci`. Now, the `initial_guess` is checked (and possibly modified) to ensure that it lies within (but not on) the user-supplied bounds:

```r
lower_temp <- lower + 0.01 * (upper - lower)
upper_temp <- upper - 0.01 * (upper - lower)

initial_guess <- pmax(initial_guess, lower_temp)
initial_guess <- pmin(initial_guess, upper_temp)
```

This is an important bug fix, so it justifies a new version of the package.