### PR TITLE
Add an option to remove Y error bars

### DIFF
--- a/R/xyplot_avg_rc.R
+++ b/R/xyplot_avg_rc.R
@@ -3,6 +3,7 @@ xyplot_avg_rc <- function(
     X,
     point_identifier,
     group_identifier,
+    y_error_bars = TRUE,
     x_error_bars = FALSE,
     cols = multi_curve_colors(),
     eb_length = 0.05,
@@ -95,8 +96,10 @@ xyplot_avg_rc <- function(
             superpose.symbol = list(col = rc_cols)
         ),
         panel = function(x, y, ...) {
-            lattice::panel.arrows(x, y, x, tdf_stats[['Y_upper']], length = eb_length, angle = 90, col = rc_error_cols, lwd = eb_lwd)
-            lattice::panel.arrows(x, y, x, tdf_stats[['Y_lower']], length = eb_length, angle = 90, col = rc_error_cols, lwd = eb_lwd)
+            if (y_error_bars) {
+                lattice::panel.arrows(x, y, x, tdf_stats[['Y_upper']], length = eb_length, angle = 90, col = rc_error_cols, lwd = eb_lwd)
+                lattice::panel.arrows(x, y, x, tdf_stats[['Y_lower']], length = eb_length, angle = 90, col = rc_error_cols, lwd = eb_lwd)
+            }
 
             if(x_error_bars) {
                 lattice::panel.arrows(x, y, tdf_stats[['X_upper']], y, length = eb_length, angle = 90, col = rc_error_cols, lwd = eb_lwd)

--- a/example_scripts/induction.R
+++ b/example_scripts/induction.R
@@ -160,9 +160,9 @@ if (VIEW_DATA_FRAMES) {
     View(all_stats)
 }
 
-###                            ###
-### PLOT RESPONSE CURVES TO CI ###
-###                            ###
+###                              ###
+### PLOT RESPONSE CURVES TO TIME ###
+###                              ###
 
 rc_caption <- "Average response curves for each event"
 
@@ -180,7 +180,7 @@ avg_plot_param <- list(
 )
 
 invisible(lapply(avg_plot_param, function(x) {
-    plot_obj <- do.call(xyplot_avg_rc, c(x, list(
+    plot_obj <- do.call(xyplot_avg_rc, c(x, y_error_bars = FALSE, list(
         type = 'b',
         pch = 20,
         auto = TRUE,

--- a/man/xyplot_avg_rc.Rd
+++ b/man/xyplot_avg_rc.Rd
@@ -15,6 +15,7 @@
     X,
     point_identifier,
     group_identifier,
+    y_error_bars = TRUE,
     x_error_bars = FALSE,
     cols = multi_curve_colors(),
     eb_length = 0.05,
@@ -37,6 +38,10 @@
   \item{group_identifier}{
     A vector with the same length as \code{Y} that indicates the "group" of each
     response curve.
+  }
+
+  \item{y_error_bars}{
+    A logical value indicating whether to plot y-axis error bars.
   }
 
   \item{x_error_bars}{


### PR DESCRIPTION
This PR adds a new argument to `xyplot_avg_rc` so that y-axis error bars can be disabled. This is especially useful for induction curves where there may be hundreds of points with relatively large error bars; in this case, the error bars make it difficult to interpret the plot.