### PR TITLE
Improve file examples

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,6 +20,8 @@ Imports:
 Suggests:
     knitr,
     rmarkdown,
-    plantecophys
+    plantecophys,
+    testthat (>= 3.0.0)
 VignetteBuilder: knitr
 URL: https://github.com/eloch216/PhotoGEA, https://eloch216.github.io/PhotoGEA/
+Config/testthat/edition: 3

--- a/NEWS.md
+++ b/NEWS.md
@@ -41,6 +41,9 @@ for the next release.
 - Added a new R file (`constants.R`) to store the values of some constants that
   appear in multiple functions; this will help ensure that consistent values
   are used in each instance.
+- Improved some error handling in `read_gasex_file` and attempted to clarify
+  instructions for selecting files to load.
+- Added two basic tests of `read_gasex_file` using the `testthat` package.
 
 # PhotoGEA VERSION 0.8.0 (2023-04-30)
 

--- a/R/read_gasex_file.R
+++ b/R/read_gasex_file.R
@@ -8,6 +8,18 @@ read_gasex_file <- function(
 )
 {
     # Some basic input checking
+    if (file_name == '') {
+        stop(
+            'The `file_name` input argument is an empty string. If ',
+            '`file_name` was generated using `system.file`, this means ',
+            'that the desired file could not be found.'
+        )
+    }
+
+    if (!file.exists(file_name)) {
+        stop('`', file_name, '` does not exist')
+    }
+
     if (!is.list(posix_options)) {
         stop('posix_options must be a list')
     }

--- a/man/apply_gm.Rd
+++ b/man/apply_gm.Rd
@@ -144,7 +144,7 @@
 \examples{
 # Read an example Licor file included in the PhotoGEA package
 licor_file <- read_gasex_file(
-  system.file("extdata", "ball_berry_1.xlsx", package = "PhotoGEA")
+  system.file('extdata', 'ball_berry_1.xlsx', package = 'PhotoGEA', mustWork = TRUE)
 )
 
 # Calculate the total pressure in the Licor chamber

--- a/man/barchart_with_errorbars.Rd
+++ b/man/barchart_with_errorbars.Rd
@@ -68,7 +68,7 @@
 \examples{
 # Read an example Licor file included in the PhotoGEA package
 licor_file <- read_gasex_file(
-  system.file("extdata", "ball_berry_1.xlsx", package = "PhotoGEA")
+  system.file('extdata', 'ball_berry_1.xlsx', package = 'PhotoGEA', mustWork = TRUE)
 )
 
 # Plot the average assimilation value for each species. (Note: this is not a

--- a/man/basic_stats.Rd
+++ b/man/basic_stats.Rd
@@ -46,7 +46,7 @@
 \examples{
 # Read an example Licor file included in the PhotoGEA package
 licor_file <- read_gasex_file(
-  system.file("extdata", "ball_berry_1.xlsx", package = "PhotoGEA")
+  system.file('extdata', 'ball_berry_1.xlsx', package = 'PhotoGEA', mustWork = TRUE)
 )
 
 # Calculate the average assimilation and stomatal conductance values for each

--- a/man/by.exdf.Rd
+++ b/man/by.exdf.Rd
@@ -35,7 +35,7 @@
 # Read a Licor file, split it into chunks according to the `species` column,
 # and count the number of measurements for each species
 licor_file <- read_gasex_file(
-  system.file("extdata", "ball_berry_1.xlsx", package = "PhotoGEA")
+  system.file('extdata', 'ball_berry_1.xlsx', package = 'PhotoGEA', mustWork = TRUE)
 )
 
 by(licor_file, licor_file[, 'species'], nrow)

--- a/man/calculate_arrhenius.Rd
+++ b/man/calculate_arrhenius.Rd
@@ -107,7 +107,7 @@
 \examples{
 # Read an example Licor file included in the PhotoGEA package
 licor_file <- read_gasex_file(
-  system.file("extdata", "ball_berry_1.xlsx", package = "PhotoGEA")
+  system.file('extdata', 'ball_berry_1.xlsx', package = 'PhotoGEA', mustWork = TRUE)
 )
 
 licor_file <- calculate_arrhenius(licor_file, c3_arrhenius_sharkey)

--- a/man/calculate_ball_berry_index.Rd
+++ b/man/calculate_ball_berry_index.Rd
@@ -73,7 +73,7 @@
 # total pressure, calculate additional gas properties, and finally calculate the
 # Ball-Berry index.
 licor_file <- read_gasex_file(
-  system.file("extdata", "ball_berry_1.xlsx", package = "PhotoGEA")
+  system.file('extdata', 'ball_berry_1.xlsx', package = 'PhotoGEA', mustWork = TRUE)
 )
 
 licor_file <- calculate_total_pressure(licor_file)

--- a/man/calculate_gas_properties.Rd
+++ b/man/calculate_gas_properties.Rd
@@ -197,7 +197,7 @@
 # Read an example Licor file included in the PhotoGEA package, calculate the
 # total pressure, and calculate additional gas properties.
 licor_file <- read_gasex_file(
-  system.file("extdata", "ball_berry_1.xlsx", package = "PhotoGEA")
+  system.file('extdata', 'ball_berry_1.xlsx', package = 'PhotoGEA', mustWork = TRUE)
 )
 
 licor_file <- calculate_total_pressure(licor_file)

--- a/man/calculate_gm_ubierna.Rd
+++ b/man/calculate_gm_ubierna.Rd
@@ -151,7 +151,7 @@
 # Read the TDL data file, making sure to interpret the time zone as US Central
 # time
 tdl_data <- read_gasex_file(
-  system.file('extdata', 'tdl_for_gm.dat', package = 'PhotoGEA'),
+  system.file('extdata', 'tdl_for_gm.dat', package = 'PhotoGEA', mustWork = TRUE),
   'TIMESTAMP',
   list(tz = 'US/Central')
 )
@@ -184,7 +184,7 @@ processed_tdl <- consolidate(by(
 # Read the gas exchange data, making sure to interpret the time stamp in the US
 # Central time zone
 licor_data <- read_gasex_file(
-  system.file('extdata', 'licor_for_gm_site11.xlsx', package = 'PhotoGEA'),
+  system.file('extdata', 'licor_for_gm_site11.xlsx', package = 'PhotoGEA', mustWork = TRUE),
   'time',
   list(tz = 'US/Central')
 )

--- a/man/calculate_ternary_correction.Rd
+++ b/man/calculate_ternary_correction.Rd
@@ -108,7 +108,7 @@
 
 # Read the gas exchange data
 licor_data <- read_gasex_file(
-  system.file('extdata', 'licor_for_gm_site11.xlsx', package = 'PhotoGEA'),
+  system.file('extdata', 'licor_for_gm_site11.xlsx', package = 'PhotoGEA', mustWork = TRUE),
   'time'
 )
 

--- a/man/calculate_total_pressure.Rd
+++ b/man/calculate_total_pressure.Rd
@@ -56,7 +56,7 @@
 # Read an example Licor file included in the PhotoGEA package and calculate the
 # total pressure.
 licor_file <- read_gasex_file(
-  system.file("extdata", "ball_berry_1.xlsx", package = "PhotoGEA")
+  system.file('extdata', 'ball_berry_1.xlsx', package = 'PhotoGEA', mustWork = TRUE)
 )
 
 licor_file <- calculate_total_pressure(licor_file)

--- a/man/check_licor_data.Rd
+++ b/man/check_licor_data.Rd
@@ -94,7 +94,7 @@
 # identified by the values of its 'species' and 'plot' columns. Since these are
 # light-response curves, each one follows a pre-set sequence of `Qin` values.
 licor_file <- read_gasex_file(
-  system.file('extdata', 'ball_berry_1.xlsx', package = 'PhotoGEA')
+  system.file('extdata', 'ball_berry_1.xlsx', package = 'PhotoGEA', mustWork = TRUE)
 )
 
 # Make sure there are no infinite values and that all curves have the same

--- a/man/example_data_files.Rd
+++ b/man/example_data_files.Rd
@@ -90,18 +90,18 @@
 
 \examples{
 # Print full paths to the example files
-system.file('extdata', 'ball_berry_1.xlsx', package = 'PhotoGEA')
-system.file('extdata', 'ball_berry_2.xlsx', package = 'PhotoGEA')
-system.file('extdata', 'c3_aci_1.xlsx', package = 'PhotoGEA')
-system.file('extdata', 'c3_aci_2.xlsx', package = 'PhotoGEA')
-system.file('extdata', 'c4_aci_1.xlsx', package = 'PhotoGEA')
-system.file('extdata', 'c4_aci_2.xlsx', package = 'PhotoGEA')
-system.file('extdata', 'licor_for_gm_site11.xlsx', package = 'PhotoGEA')
-system.file('extdata', 'licor_for_gm_site13.xlsx', package = 'PhotoGEA')
-system.file('extdata', 'plaintext_licor_file', package = 'PhotoGEA')
-system.file('extdata', 'tdl_for_gm.dat', package = 'PhotoGEA')
-system.file('extdata', 'tdl_sampling_1.dat', package = 'PhotoGEA')
-system.file('extdata', 'tdl_sampling_2.dat', package = 'PhotoGEA')
+system.file('extdata', 'ball_berry_1.xlsx', package = 'PhotoGEA', mustWork = TRUE)
+system.file('extdata', 'ball_berry_2.xlsx', package = 'PhotoGEA', mustWork = TRUE)
+system.file('extdata', 'c3_aci_1.xlsx', package = 'PhotoGEA', mustWork = TRUE)
+system.file('extdata', 'c3_aci_2.xlsx', package = 'PhotoGEA', mustWork = TRUE)
+system.file('extdata', 'c4_aci_1.xlsx', package = 'PhotoGEA', mustWork = TRUE)
+system.file('extdata', 'c4_aci_2.xlsx', package = 'PhotoGEA', mustWork = TRUE)
+system.file('extdata', 'licor_for_gm_site11.xlsx', package = 'PhotoGEA', mustWork = TRUE)
+system.file('extdata', 'licor_for_gm_site13.xlsx', package = 'PhotoGEA', mustWork = TRUE)
+system.file('extdata', 'plaintext_licor_file', package = 'PhotoGEA', mustWork = TRUE)
+system.file('extdata', 'tdl_for_gm.dat', package = 'PhotoGEA', mustWork = TRUE)
+system.file('extdata', 'tdl_sampling_1.dat', package = 'PhotoGEA', mustWork = TRUE)
+system.file('extdata', 'tdl_sampling_2.dat', package = 'PhotoGEA', mustWork = TRUE)
 }
 
 \keyword{datasets}

--- a/man/exclude_outliers.Rd
+++ b/man/exclude_outliers.Rd
@@ -53,7 +53,7 @@
 # several light response curves that can be identified by the 'species' and
 # 'plot' columns.
 licor_file <- read_gasex_file(
-  system.file("extdata", "ball_berry_1.xlsx", package = "PhotoGEA")
+  system.file('extdata', 'ball_berry_1.xlsx', package = 'PhotoGEA', mustWork = TRUE)
 )
 
 # Exclude points from each response curve in the data where the leaf temperature

--- a/man/fit_ball_berry.Rd
+++ b/man/fit_ball_berry.Rd
@@ -113,7 +113,7 @@
 # that uniquely identifies each curve, and then perform a fit to extract the
 # Ball-Berry parameters from each curve.
 licor_file <- read_gasex_file(
-  system.file("extdata", "ball_berry_1.xlsx", package = "PhotoGEA")
+  system.file('extdata', 'ball_berry_1.xlsx', package = 'PhotoGEA', mustWork = TRUE)
 )
 
 licor_file <- calculate_total_pressure(licor_file)

--- a/man/fit_c3_aci.Rd
+++ b/man/fit_c3_aci.Rd
@@ -280,7 +280,7 @@
 \examples{
 # Read an example Licor file included in the PhotoGEA package
 licor_file <- read_gasex_file(
-  system.file('extdata', 'c3_aci_1.xlsx', package = 'PhotoGEA')
+  system.file('extdata', 'c3_aci_1.xlsx', package = 'PhotoGEA', mustWork = TRUE)
 )
 
 # Define a new column that uniquely identifies each curve

--- a/man/fit_c4_aci.Rd
+++ b/man/fit_c4_aci.Rd
@@ -243,7 +243,7 @@
 \examples{
 # Read an example Licor file included in the PhotoGEA package
 licor_file <- read_gasex_file(
-  system.file('extdata', 'c4_aci_1.xlsx', package = 'PhotoGEA')
+  system.file('extdata', 'c4_aci_1.xlsx', package = 'PhotoGEA', mustWork = TRUE)
 )
 
 # Define a new column that uniquely identifies each curve

--- a/man/get_oxygen_from_preamble.Rd
+++ b/man/get_oxygen_from_preamble.Rd
@@ -40,7 +40,7 @@
 
 # Read the file
 licor_data <- read_gasex_file(
-  system.file('extdata', 'licor_for_gm_site11.xlsx', package = 'PhotoGEA'),
+  system.file('extdata', 'licor_for_gm_site11.xlsx', package = 'PhotoGEA', mustWork = TRUE),
 )
 
 # Here we can see the oxygen percentage in the preamble

--- a/man/get_sample_valve_from_filename.Rd
+++ b/man/get_sample_valve_from_filename.Rd
@@ -66,7 +66,7 @@
 
 # Read the gas exchange data
 licor_data <- read_gasex_file(
-  system.file('extdata', 'licor_for_gm_site11.xlsx', package = 'PhotoGEA'),
+  system.file('extdata', 'licor_for_gm_site11.xlsx', package = 'PhotoGEA', mustWork = TRUE),
 )
 
 # Get TDL valve information from Licor file name; for this TDL system, the

--- a/man/identify_tdl_cycles.Rd
+++ b/man/identify_tdl_cycles.Rd
@@ -101,7 +101,7 @@
 # Example: reading a TDL file that is included with the PhotoGEA package and
 # identifying its measurement cycles.
 tdl_file <- read_gasex_file(
-  system.file("extdata", "tdl_sampling_1.dat", package = "PhotoGEA"),
+  system.file('extdata', 'tdl_sampling_1.dat', package = 'PhotoGEA', mustWork = TRUE),
   'TIMESTAMP'
 )
 

--- a/man/initial_guess_c3_aci.Rd
+++ b/man/initial_guess_c3_aci.Rd
@@ -151,7 +151,7 @@
 \examples{
 # Read an example Licor file included in the PhotoGEA package
 licor_file <- read_gasex_file(
-  system.file('extdata', 'c3_aci_1.xlsx', package = 'PhotoGEA')
+  system.file('extdata', 'c3_aci_1.xlsx', package = 'PhotoGEA', mustWork = TRUE)
 )
 
 # Define a new column that uniquely identifies each curve

--- a/man/initial_guess_c4_aci.Rd
+++ b/man/initial_guess_c4_aci.Rd
@@ -138,7 +138,7 @@
 \examples{
 # Read an example Licor file included in the PhotoGEA package
 licor_file <- read_gasex_file(
-  system.file('extdata', 'c4_aci_1.xlsx', package = 'PhotoGEA')
+  system.file('extdata', 'c4_aci_1.xlsx', package = 'PhotoGEA', mustWork = TRUE)
 )
 
 # Define a new column that uniquely identifies each curve

--- a/man/organize_response_curve_data.Rd
+++ b/man/organize_response_curve_data.Rd
@@ -96,7 +96,7 @@
 # identified by the values of its 'species' and 'plot' columns. Since these are
 # light-response curves, each one follows a pre-set sequence of `Qin` values.
 licor_file <- read_gasex_file(
-  system.file('extdata', 'ball_berry_1.xlsx', package = 'PhotoGEA')
+  system.file('extdata', 'ball_berry_1.xlsx', package = 'PhotoGEA', mustWork = TRUE)
 )
 
 # Split the data into individual curves, keep all seven measurement points in

--- a/man/pair_gasex_and_tdl.Rd
+++ b/man/pair_gasex_and_tdl.Rd
@@ -83,7 +83,7 @@
 # Read the TDL data file, making sure to interpret the time zone as US Central
 # time
 tdl_data <- read_gasex_file(
-  system.file('extdata', 'tdl_for_gm.dat', package = 'PhotoGEA'),
+  system.file('extdata', 'tdl_for_gm.dat', package = 'PhotoGEA', mustWork = TRUE),
   'TIMESTAMP',
   list(tz = 'US/Central')
 )
@@ -116,7 +116,7 @@ processed_tdl <- consolidate(by(
 # Read the gas exchange data, making sure to interpret the time stamp in the US
 # Central time zone
 licor_data <- read_gasex_file(
-  system.file('extdata', 'licor_for_gm_site11.xlsx', package = 'PhotoGEA'),
+  system.file('extdata', 'licor_for_gm_site11.xlsx', package = 'PhotoGEA', mustWork = TRUE),
   'time',
   list(tz = 'US/Central')
 )

--- a/man/process_tdl_cycle_erml.Rd
+++ b/man/process_tdl_cycle_erml.Rd
@@ -142,7 +142,7 @@
 # Example: reading a TDL file that is included with the PhotoGEA package,
 # identifying its measurement cycles, and then process them.
 tdl_file <- read_gasex_file(
-  system.file("extdata", "tdl_sampling_1.dat", package = "PhotoGEA"),
+  system.file('extdata', 'tdl_sampling_1.dat', package = 'PhotoGEA', mustWork = TRUE),
   'TIMESTAMP'
 )
 

--- a/man/read_cr3000.Rd
+++ b/man/read_cr3000.Rd
@@ -69,7 +69,7 @@
 \examples{
 # Example: reading a TDL file that is included with the PhotoGEA package.
 tdl_file <- PhotoGEA:::read_cr3000(
-  system.file("extdata", "tdl_sampling_1.dat", package = "PhotoGEA")
+  system.file('extdata', 'tdl_sampling_1.dat', package = 'PhotoGEA', mustWork = TRUE)
 )
 
 tdl_file$file_name # A record of where the data came from

--- a/man/read_gasex_file.Rd
+++ b/man/read_gasex_file.Rd
@@ -141,7 +141,7 @@
 # Example: Eeading a Licor Excel file that is included with the PhotoGEA
 # package. Here we specify 'time' as the name of the timestamp column.
 licor_file <- read_gasex_file(
-  system.file("extdata", "ball_berry_1.xlsx", package = "PhotoGEA"),
+  system.file('extdata', 'ball_berry_1.xlsx', package = 'PhotoGEA', mustWork = TRUE),
   'time'
 )
 

--- a/man/read_licor_6800_Excel.Rd
+++ b/man/read_licor_6800_Excel.Rd
@@ -67,14 +67,14 @@
 # Example 1: Reading a Licor Excel file that is included with the PhotoGEA
 # package.
 licor_file <- PhotoGEA:::read_licor_6800_Excel(
-  system.file("extdata", "ball_berry_1.xlsx", package = "PhotoGEA")
+  system.file('extdata', 'ball_berry_1.xlsx', package = 'PhotoGEA', mustWork = TRUE)
 )
 
 # Example 2: Reading a Licor Excel file that is included with the PhotoGEA
 # package; here we use a different column name to identify the data block within
 # the file's contents.
 licor_file <- PhotoGEA:::read_licor_6800_Excel(
-  system.file("extdata", "ball_berry_1.xlsx", package = "PhotoGEA"),
+  system.file('extdata', 'ball_berry_1.xlsx', package = 'PhotoGEA', mustWork = TRUE),
   column_name = 'A'
 )
 }

--- a/man/read_licor_6800_plaintext.Rd
+++ b/man/read_licor_6800_plaintext.Rd
@@ -54,7 +54,7 @@
 # Example: Reading a Licor plaintext file that is included with the PhotoGEA
 # package.
 licor_file <- PhotoGEA:::read_licor_6800_plaintext(
-  system.file("extdata", "plaintext_licor_file", package = "PhotoGEA")
+  system.file('extdata', 'plaintext_licor_file', package = 'PhotoGEA', mustWork = TRUE)
 )
 }
 

--- a/man/remove_points.Rd
+++ b/man/remove_points.Rd
@@ -35,7 +35,7 @@
 \examples{
 # Create an exdf object by reading a Licor Excel file
 licor_file <- read_gasex_file(
-  system.file("extdata", "ball_berry_1.xlsx", package = "PhotoGEA")
+  system.file('extdata', 'ball_berry_1.xlsx', package = 'PhotoGEA', mustWork = TRUE)
 )
 
 # Print the number of points in the data set

--- a/man/set_variable.Rd
+++ b/man/set_variable.Rd
@@ -103,7 +103,7 @@ print(simple_exdf)
 # As a more realistic example, load a Licor file and set different values of
 # mesophyll conductance for each species in the data set.
 licor_file <- read_gasex_file(
-  system.file("extdata", "ball_berry_1.xlsx", package = "PhotoGEA")
+  system.file('extdata', 'ball_berry_1.xlsx', package = 'PhotoGEA', mustWork = TRUE)
 )
 
 licor_file <- set_variable(

--- a/man/smooth_tdl_data.Rd
+++ b/man/smooth_tdl_data.Rd
@@ -72,7 +72,7 @@
 \examples{
 # Example 1: Smoothing the 12C signal from one TDL valve using a spline fit
 tdl_file <- read_gasex_file(
-  system.file("extdata", "tdl_sampling_1.dat", package = "PhotoGEA"),
+  system.file('extdata', 'tdl_sampling_1.dat', package = 'PhotoGEA', mustWork = TRUE),
   'TIMESTAMP'
 )
 

--- a/man/split.exdf.Rd
+++ b/man/split.exdf.Rd
@@ -41,7 +41,7 @@
 # Read a Licor file, select just a few columns, and then split it by the value
 # of the `plot` column
 licor_file <- read_gasex_file(
-  system.file("extdata", "ball_berry_1.xlsx", package = "PhotoGEA")
+  system.file('extdata', 'ball_berry_1.xlsx', package = 'PhotoGEA', mustWork = TRUE)
 )
 
 licor_file <- licor_file[, c('plot', 'species', 'Qin', 'A', 'gsw'), TRUE]

--- a/man/xyplot_avg_rc.Rd
+++ b/man/xyplot_avg_rc.Rd
@@ -73,7 +73,7 @@
 \examples{
 # Read an example Licor file included in the PhotoGEA package
 licor_file <- read_gasex_file(
-  system.file("extdata", "ball_berry_1.xlsx", package = "PhotoGEA")
+  system.file('extdata', 'ball_berry_1.xlsx', package = 'PhotoGEA', mustWork = TRUE)
 )
 
 # Organize the response curve data

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,12 @@
+# This file is part of the standard setup for testthat.
+# It is recommended that you do not modify it.
+#
+# Where should you do additional test configuration?
+# Learn more about the roles of various files in:
+# * https://r-pkgs.org/tests.html
+# * https://testthat.r-lib.org/reference/test_package.html#special-files
+
+library(testthat)
+library(PhotoGEA)
+
+test_check("PhotoGEA")

--- a/tests/testthat/test-read_gasex_file.R
+++ b/tests/testthat/test-read_gasex_file.R
@@ -1,0 +1,13 @@
+test_that('file_name cannot be an empty string', {
+    expect_error(
+        read_gasex_file(''),
+        'The `file_name` input argument is an empty string. If `file_name` was generated using `system.file`, this means that the desired file could not be found.'
+    )
+})
+
+test_that('file_name must exist', {
+    expect_error(
+        read_gasex_file('fake_file.xlsx'),
+        '`fake_file.xlsx` does not exist'
+    )
+})

--- a/vignettes/PhotoGEA.Rmd
+++ b/vignettes/PhotoGEA.Rmd
@@ -57,8 +57,8 @@ library(lattice)
 
 # Define a vector of paths to the files we wish to load
 file_paths <- c(
-  system.file('extdata', 'c3_aci_1.xlsx', package = 'PhotoGEA'),
-  system.file('extdata', 'c3_aci_2.xlsx', package = 'PhotoGEA')
+  system.file('extdata', 'c3_aci_1.xlsx', package = 'PhotoGEA', mustWork = TRUE),
+  system.file('extdata', 'c3_aci_2.xlsx', package = 'PhotoGEA', mustWork = TRUE)
 )
 
 # Load the data from each file

--- a/vignettes/PhotoGEA.Rmd
+++ b/vignettes/PhotoGEA.Rmd
@@ -46,6 +46,12 @@ model to each response curve, and then plot some of the results. This is a
 basic example that just scratches the surface of what is possible with
 `PhotoGEA`.
 
+(**Note:** When loading your own files for analysis, it is not advisable to use
+`system.file` as we have done in the code below. Instead, file paths can be
+directly written, or files can be chosen using an interactive window. See
+the [Analyzing C3 A-Ci Curves](analyzing_c3_aci_curves.html#input-files)
+vignette for more information.)
+
 ## Fitting the Curves
 
 The following code can be used to read the data and fit each curve:
@@ -55,7 +61,8 @@ The following code can be used to read the data and fit each curve:
 library(PhotoGEA)
 library(lattice)
 
-# Define a vector of paths to the files we wish to load
+# Define a vector of paths to the files we wish to load; in this case, we are
+# loading example files included with the PhotoGEA package
 file_paths <- c(
   system.file('extdata', 'c3_aci_1.xlsx', package = 'PhotoGEA', mustWork = TRUE),
   system.file('extdata', 'c3_aci_2.xlsx', package = 'PhotoGEA', mustWork = TRUE)
@@ -209,6 +216,7 @@ being added all the time:
   - [Analyzing C4 A-Ci Curves](analyzing_c4_aci_curves.html)
   - [Analyzing Ball-Berry Data](analyzing_ball_berry_data.html)
   - [Analyzing TDL Data](analyzing_tdl_data.html)
+  - [Analyzing Mesophyll Conductance Data](analyzing_gm_data.html)
 - More advanced topics:
   - [Creating Your Own Processing Tools](creating_your_own_processing_tools.html):
     Discusses how to create functions compatible with `PhotoGEA` that apply new

--- a/vignettes/analyzing_ball_berry_data.Rmd
+++ b/vignettes/analyzing_ball_berry_data.Rmd
@@ -112,12 +112,18 @@ installation directory, and full paths to these files can be obtained with
 `system.file`:
 
 ```{r licor_file_names}
-# Define a vector of paths to the files we wish to load
+# Define a vector of paths to the files we wish to load; in this case, we are
+# loading example files included with the PhotoGEA package
 file_paths <- c(
   system.file('extdata', 'ball_berry_1.xlsx', package = 'PhotoGEA', mustWork = TRUE),
   system.file('extdata', 'ball_berry_2.xlsx', package = 'PhotoGEA', mustWork = TRUE)
 )
 ```
+
+(**Note:** When loading your own files for analysis, it is not advisable to use
+`system.file` as we have done here. Instead, file paths can be directly written,
+or files can be chosen using an interactive window. See [Input Files] below for
+more information.)
 
 To actually read the data in the files and store them in R objects, we will use
 the `read_gasex_file` function from `PhotoGEA`. Since there are multiple files
@@ -555,11 +561,23 @@ not specifically mentioned here.
 ## Input Files
 
 The file paths specified in `file_paths` will need to be modified so they point
-to your Licor files. In your own script, you may want to consider using the
-`choose_input_licor_files` function from `PhotoGEA`; this function will create a
-pop-up browser window where you can interactively select a set of Excel files.
-Sometimes this is more convenient than writing out full file paths. For example,
-you could replace the previous definition of `file_paths` with this one:
+to your Licor files. One way to do this in your own script is to simply write
+out relative or absolute paths to the files you wish to load. For example, you
+could replace the previous definition of `file_paths` with this one:
+
+```{r write_file_paths, eval = FALSE}
+# Define a vector of paths to the files we wish to load
+file_paths <- c(
+  'myfile1.xlsx',        # `myfile1.xlsx` must be in the current working directory
+  'C:/documents/myfile2' # This is an absolute path to `myfile2`
+)
+```
+
+You may also want to consider using the `choose_input_licor_files` function from
+`PhotoGEA`; this function will create a pop-up browser window where you can
+interactively select a set of files. Sometimes this is more convenient than
+writing out file paths or names. For example, you could replace the previous
+definition of `file_paths` with this one:
 
 ```{r choose_licor_files, eval = FALSE}
 # Interactively define a vector of paths to the files we wish to load
@@ -628,6 +646,10 @@ vignette.
 ###
 
 <<licor_file_names>>
+
+## IMPORTANT: When loading your own files, it is not advised to use
+## `system.file` as in the above code. Instead, write out the names or use the
+## `choose_input_licor_files` function.
 
 <<loading_licor_data>>
 

--- a/vignettes/analyzing_ball_berry_data.Rmd
+++ b/vignettes/analyzing_ball_berry_data.Rmd
@@ -114,8 +114,8 @@ installation directory, and full paths to these files can be obtained with
 ```{r licor_file_names}
 # Define a vector of paths to the files we wish to load
 file_paths <- c(
-  system.file('extdata', 'ball_berry_1.xlsx', package = 'PhotoGEA'),
-  system.file('extdata', 'ball_berry_2.xlsx', package = 'PhotoGEA')
+  system.file('extdata', 'ball_berry_1.xlsx', package = 'PhotoGEA', mustWork = TRUE),
+  system.file('extdata', 'ball_berry_2.xlsx', package = 'PhotoGEA', mustWork = TRUE)
 )
 ```
 

--- a/vignettes/analyzing_c3_aci_curves.Rmd
+++ b/vignettes/analyzing_c3_aci_curves.Rmd
@@ -267,8 +267,8 @@ installation directory, and full paths to these files can be obtained with
 ```{r licor_file_names}
 # Define a vector of paths to the files we wish to load
 file_paths <- c(
-  system.file('extdata', 'c3_aci_1.xlsx', package = 'PhotoGEA'),
-  system.file('extdata', 'c3_aci_2.xlsx', package = 'PhotoGEA')
+  system.file('extdata', 'c3_aci_1.xlsx', package = 'PhotoGEA', mustWork = TRUE),
+  system.file('extdata', 'c3_aci_2.xlsx', package = 'PhotoGEA', mustWork = TRUE)
 )
 ```
 

--- a/vignettes/analyzing_c3_aci_curves.Rmd
+++ b/vignettes/analyzing_c3_aci_curves.Rmd
@@ -265,12 +265,18 @@ installation directory, and full paths to these files can be obtained with
 `system.file`:
 
 ```{r licor_file_names}
-# Define a vector of paths to the files we wish to load
+# Define a vector of paths to the files we wish to load; in this case, we are
+# loading example files included with the PhotoGEA package
 file_paths <- c(
   system.file('extdata', 'c3_aci_1.xlsx', package = 'PhotoGEA', mustWork = TRUE),
   system.file('extdata', 'c3_aci_2.xlsx', package = 'PhotoGEA', mustWork = TRUE)
 )
 ```
+
+(**Note:** When loading your own files for analysis, it is not advisable to use
+`system.file` as we have done here. Instead, file paths can be directly written,
+or files can be chosen using an interactive window. See [Input Files] below for
+more information.)
 
 To actually read the data in the files and store them in R objects, we will use
 the `read_gasex_file` function from `PhotoGEA`. Since there are multiple files
@@ -862,11 +868,23 @@ specifically mentioned here.
 ## Input Files
 
 The file paths specified in `file_paths` will need to be modified so they point
-to your Licor files. In your own script, you may want to consider using the
-`choose_input_licor_files` function from `PhotoGEA`; this function will create a
-pop-up browser window where you can interactively select a set of Licor files.
-Sometimes this is more convenient than writing out full file paths. For example,
-you could replace the previous definition of `file_paths` with this one:
+to your Licor files. One way to do this in your own script is to simply write
+out relative or absolute paths to the files you wish to load. For example, you
+could replace the previous definition of `file_paths` with this one:
+
+```{r write_file_paths, eval = FALSE}
+# Define a vector of paths to the files we wish to load
+file_paths <- c(
+  'myfile1.xlsx',        # `myfile1.xlsx` must be in the current working directory
+  'C:/documents/myfile2' # This is an absolute path to `myfile2`
+)
+```
+
+You may also want to consider using the `choose_input_licor_files` function from
+`PhotoGEA`; this function will create a pop-up browser window where you can
+interactively select a set of files. Sometimes this is more convenient than
+writing out file paths or names. For example, you could replace the previous
+definition of `file_paths` with this one:
 
 ```{r choose_licor_files, eval = FALSE}
 # Interactively define a vector of paths to the files we wish to load
@@ -947,6 +965,10 @@ vignette.
 ###
 
 <<licor_file_names>>
+
+## IMPORTANT: When loading your own files, it is not advised to use
+## `system.file` as in the above code. Instead, write out the names or use the
+## `choose_input_licor_files` function.
 
 <<loading_licor_data>>
 

--- a/vignettes/analyzing_c4_aci_curves.Rmd
+++ b/vignettes/analyzing_c4_aci_curves.Rmd
@@ -235,8 +235,8 @@ installation directory, and full paths to these files can be obtained with
 ```{r licor_file_names}
 # Define a vector of paths to the files we wish to load
 file_paths <- c(
-  system.file('extdata', 'c4_aci_1.xlsx', package = 'PhotoGEA'),
-  system.file('extdata', 'c4_aci_2.xlsx', package = 'PhotoGEA')
+  system.file('extdata', 'c4_aci_1.xlsx', package = 'PhotoGEA', mustWork = TRUE),
+  system.file('extdata', 'c4_aci_2.xlsx', package = 'PhotoGEA', mustWork = TRUE)
 )
 ```
 

--- a/vignettes/analyzing_c4_aci_curves.Rmd
+++ b/vignettes/analyzing_c4_aci_curves.Rmd
@@ -233,12 +233,18 @@ installation directory, and full paths to these files can be obtained with
 `system.file`:
 
 ```{r licor_file_names}
-# Define a vector of paths to the files we wish to load
+# Define a vector of paths to the files we wish to load; in this case, we are
+# loading example files included with the PhotoGEA package
 file_paths <- c(
   system.file('extdata', 'c4_aci_1.xlsx', package = 'PhotoGEA', mustWork = TRUE),
   system.file('extdata', 'c4_aci_2.xlsx', package = 'PhotoGEA', mustWork = TRUE)
 )
 ```
+
+(**Note:** When loading your own files for analysis, it is not advisable to use
+`system.file` as we have done here. Instead, file paths can be directly written,
+or files can be chosen using an interactive window. See [Input Files] below for
+more information.)
 
 To actually read the data in the files and store them in R objects, we will use
 the `read_gasex_file` function from `PhotoGEA`. Since there are multiple files
@@ -795,11 +801,23 @@ specifically mentioned here.
 ## Input Files
 
 The file paths specified in `file_paths` will need to be modified so they point
-to your Licor files. In your own script, you may want to consider using the
-`choose_input_licor_files` function from `PhotoGEA`; this function will create a
-pop-up browser window where you can interactively select a set of Licor files.
-Sometimes this is more convenient than writing out full file paths. For example,
-you could replace the previous definition of `file_paths` with this one:
+to your Licor files. One way to do this in your own script is to simply write
+out relative or absolute paths to the files you wish to load. For example, you
+could replace the previous definition of `file_paths` with this one:
+
+```{r write_file_paths, eval = FALSE}
+# Define a vector of paths to the files we wish to load
+file_paths <- c(
+  'myfile1.xlsx',        # `myfile1.xlsx` must be in the current working directory
+  'C:/documents/myfile2' # This is an absolute path to `myfile2`
+)
+```
+
+You may also want to consider using the `choose_input_licor_files` function from
+`PhotoGEA`; this function will create a pop-up browser window where you can
+interactively select a set of files. Sometimes this is more convenient than
+writing out file paths or names. For example, you could replace the previous
+definition of `file_paths` with this one:
 
 ```{r choose_licor_files, eval = FALSE}
 # Interactively define a vector of paths to the files we wish to load
@@ -871,6 +889,10 @@ vignette.
 ###
 
 <<licor_file_names>>
+
+## IMPORTANT: When loading your own files, it is not advised to use
+## `system.file` as in the above code. Instead, write out the names or use the
+## `choose_input_licor_files` function.
 
 <<loading_licor_data>>
 

--- a/vignettes/analyzing_gm_data.Rmd
+++ b/vignettes/analyzing_gm_data.Rmd
@@ -165,12 +165,18 @@ installation directory, and full paths to these files can be obtained with
 `system.file`:
 
 ```{r licor_file_names}
-# Define a vector of paths to the files we wish to load
+# Define a vector of paths to the files we wish to load; in this case, we are
+# loading example files included with the PhotoGEA package
 licor_file_paths <- c(
   system.file('extdata', 'licor_for_gm_site11.xlsx', package = 'PhotoGEA', mustWork = TRUE),
   system.file('extdata', 'licor_for_gm_site13.xlsx', package = 'PhotoGEA', mustWork = TRUE)
 )
 ```
+
+(**Note:** When loading your own files for analysis, it is not advisable to use
+`system.file` as we have done here. Instead, file paths can be directly written,
+or files can be chosen using an interactive window. See [Input Files] below for
+more information.)
 
 To actually read the data in the files and store them in R objects, we will use
 the `read_gasex_file` function from `PhotoGEA`. Later, we will need to match
@@ -269,11 +275,17 @@ installation directory, and a full path to the file can be obtained with
 `system.file`:
 
 ```{r tdl_file_names}
-# Define a vector of paths to the files we wish to load
+# Define a vector of paths to the files we wish to load; in this case, we are
+# loading example files included with the PhotoGEA package
 tdl_file_paths <- c(
   system.file('extdata', 'tdl_for_gm.dat', package = 'PhotoGEA', mustWork = TRUE)
 )
 ```
+
+(**Note:** When loading your own files for analysis, it is not advisable to use
+`system.file` as we have done here. Instead, file paths can be directly written,
+or files can be chosen using an interactive window. See [Input Files] below for
+more information.)
 
 To actually read the data in the files and store them in R objects, we will use
 the `read_gasex_file` function from `PhotoGEA`. Later, we will need to match
@@ -781,12 +793,29 @@ specifically mentioned here.
 ## Input Files
 
 The file paths specified in `licor_file_paths` and `tdl_file_paths` will need to
-be modified so they point to your own data files. In your own script, you may
-want to consider using the `choose_input_licor_files` and
+be modified so they point to your own files. One way to do this in your own
+script is to simply write out relative or absolute paths to the files you wish
+to load. For example, you could replace the previous definitions with these
+ones:
+
+```{r write_file_paths, eval = FALSE}
+# Define a vector of paths to the files we wish to load
+licor_file_paths <- c(
+  'myfile1.xlsx',        # `myfile1.xlsx` must be in the current working directory
+  'C:/documents/myfile2' # This is an absolute path to `myfile2`
+)
+
+tdl_file_paths <- c(
+  'tdl_1.dat',     # `tdl_1.dat` must be in the current working directory
+  'data/tdl_2.dat' # The current working directory must contain a subdirectory
+)                  # called `data` that contains `tdl2.dat`
+```
+
+You may also want to consider using the `choose_input_licor_files` and
 `choose_input_tdl_files` functions from `PhotoGEA`; these functions will create
-pop-up browser windows where you can interactively select a set of data files.
-Sometimes this is more convenient than writing out full file paths. For example,
-you could replace the previous definitions with these ones:
+pop-up browser windows where you can interactively select a set of files.
+Sometimes this is more convenient than writing out file paths or names. For
+example, you could replace the previous definitions with these ones:
 
 ```{r choose_files, eval = FALSE}
 # Interactively define a vector of paths to the files we wish to load
@@ -848,6 +877,10 @@ vignette.
 
 <<licor_file_names>>
 
+## IMPORTANT: When loading your own files, it is not advised to use
+## `system.file` as in the above code. Instead, write out the names or use the
+## `choose_input_licor_files` function.
+
 <<loading_licor_data>>
 
 <<oxygen_concentration>>
@@ -861,6 +894,10 @@ vignette.
 ##
 
 <<tdl_file_names>>
+
+## IMPORTANT: When loading your own files, it is not advised to use
+## `system.file` as in the above code. Instead, write out the names or use the
+## `choose_input_tdl_files` function.
 
 <<loading_tdl_data>>
 

--- a/vignettes/analyzing_gm_data.Rmd
+++ b/vignettes/analyzing_gm_data.Rmd
@@ -167,8 +167,8 @@ installation directory, and full paths to these files can be obtained with
 ```{r licor_file_names}
 # Define a vector of paths to the files we wish to load
 licor_file_paths <- c(
-  system.file('extdata', 'licor_for_gm_site11.xlsx', package = 'PhotoGEA'),
-  system.file('extdata', 'licor_for_gm_site13.xlsx', package = 'PhotoGEA')
+  system.file('extdata', 'licor_for_gm_site11.xlsx', package = 'PhotoGEA', mustWork = TRUE),
+  system.file('extdata', 'licor_for_gm_site13.xlsx', package = 'PhotoGEA', mustWork = TRUE)
 )
 ```
 
@@ -271,7 +271,7 @@ installation directory, and a full path to the file can be obtained with
 ```{r tdl_file_names}
 # Define a vector of paths to the files we wish to load
 tdl_file_paths <- c(
-  system.file('extdata', 'tdl_for_gm.dat', package = 'PhotoGEA')
+  system.file('extdata', 'tdl_for_gm.dat', package = 'PhotoGEA', mustWork = TRUE)
 )
 ```
 

--- a/vignettes/analyzing_tdl_data.Rmd
+++ b/vignettes/analyzing_tdl_data.Rmd
@@ -96,8 +96,8 @@ installation directory, and full paths to these files can be obtained with
 ```{r tdl_file_names}
 # Define a vector of paths to the files we wish to load
 file_paths <- c(
-  system.file('extdata', 'tdl_sampling_1.dat', package = 'PhotoGEA'),
-  system.file('extdata', 'tdl_sampling_2.dat', package = 'PhotoGEA')
+  system.file('extdata', 'tdl_sampling_1.dat', package = 'PhotoGEA', mustWork = TRUE),
+  system.file('extdata', 'tdl_sampling_2.dat', package = 'PhotoGEA', mustWork = TRUE)
 )
 ```
 

--- a/vignettes/analyzing_tdl_data.Rmd
+++ b/vignettes/analyzing_tdl_data.Rmd
@@ -94,12 +94,18 @@ installation directory, and full paths to these files can be obtained with
 `system.file`:
 
 ```{r tdl_file_names}
-# Define a vector of paths to the files we wish to load
+# Define a vector of paths to the files we wish to load; in this case, we are
+# loading example files included with the PhotoGEA package
 file_paths <- c(
   system.file('extdata', 'tdl_sampling_1.dat', package = 'PhotoGEA', mustWork = TRUE),
   system.file('extdata', 'tdl_sampling_2.dat', package = 'PhotoGEA', mustWork = TRUE)
 )
 ```
+
+(**Note:** When loading your own files for analysis, it is not advisable to use
+`system.file` as we have done here. Instead, file paths can be directly written,
+or files can be chosen using an interactive window. See [Input Files] below for
+more information.)
 
 To actually read the data in the files and store them in R objects, we will use
 the `read_gasex_file` function from `PhotoGEA`. Since there are multiple files
@@ -570,11 +576,23 @@ specifically mentioned here.
 ## Input Files
 
 The file paths specified in `file_paths` will need to be modified so they point
-to your TDL data files. In your own script, you may want to consider using the
-`choose_input_tdl_files` function from `PhotoGEA`; this function will create a
-pop-up browser window where you can interactively select a set of `.dat` files.
-Sometimes this is more convenient than writing out full file paths. For example,
-you could replace the previous definition of `file_paths` with this one:
+to your TDL files. One way to do this in your own script is to simply write
+out relative or absolute paths to the files you wish to load. For example, you
+could replace the previous definition of `file_paths` with this one:
+
+```{r write_file_paths, eval = FALSE}
+# Define a vector of paths to the files we wish to load
+file_paths <- c(
+  'myfile1.dat',             # `myfile1.dat` must be in the current working directory
+  'C:/documents/myfile2.dat' # This is an absolute path to `myfile2.dat`
+)
+```
+
+You may also want to consider using the `choose_input_tdl_files` function from
+`PhotoGEA`; this function will create a pop-up browser window where you can
+interactively select a set of files. Sometimes this is more convenient than
+writing out file paths or names. For example, you could replace the previous
+definition of `file_paths` with this one:
 
 ```{r choose_tdl_files, eval = FALSE}
 # Interactively define a vector of paths to the files we wish to load
@@ -651,6 +669,10 @@ vignette.
 ###
 
 <<tdl_file_names>>
+
+## IMPORTANT: When loading your own files, it is not advised to use
+## `system.file` as in the above code. Instead, write out the names or use the
+## `choose_input_tdl_files` function.
 
 <<loading_tdl_data>>
 

--- a/vignettes/combining_with_other_packages.Rmd
+++ b/vignettes/combining_with_other_packages.Rmd
@@ -89,8 +89,8 @@ included here, but they can be found at the end of this vignette in
 ```{r loading_and_validating_data, echo = FALSE}
 # Define a vector of paths to the files we wish to load
 file_paths <- c(
-  system.file('extdata', 'c3_aci_1.xlsx', package = 'PhotoGEA'),
-  system.file('extdata', 'c3_aci_2.xlsx', package = 'PhotoGEA')
+  system.file('extdata', 'c3_aci_1.xlsx', package = 'PhotoGEA', mustWork = TRUE),
+  system.file('extdata', 'c3_aci_2.xlsx', package = 'PhotoGEA', mustWork = TRUE)
 )
 
 # Load each file, storing the result in a list

--- a/vignettes/creating_your_own_processing_tools.Rmd
+++ b/vignettes/creating_your_own_processing_tools.Rmd
@@ -63,8 +63,8 @@ included here, but they can be found at the end of this vignette in
 ```{r loading_and_validating_data, echo = FALSE}
 # Define a vector of paths to the files we wish to load
 file_paths <- c(
-  system.file('extdata', 'c3_aci_1.xlsx', package = 'PhotoGEA'),
-  system.file('extdata', 'c3_aci_2.xlsx', package = 'PhotoGEA')
+  system.file('extdata', 'c3_aci_1.xlsx', package = 'PhotoGEA', mustWork = TRUE),
+  system.file('extdata', 'c3_aci_2.xlsx', package = 'PhotoGEA', mustWork = TRUE)
 )
 
 # Load each file, storing the result in a list

--- a/vignettes/working_with_extended_data_frames.Rmd
+++ b/vignettes/working_with_extended_data_frames.Rmd
@@ -188,7 +188,7 @@ Microsoft Excel file containing Licor measurements.
 
 ```{r}
 exdf_3 <- read_gasex_file(
-  system.file("extdata", "ball_berry_1.xlsx", package = "PhotoGEA")
+  system.file('extdata', 'ball_berry_1.xlsx', package = 'PhotoGEA', mustWork = TRUE)
 )
 ```
 
@@ -420,8 +420,8 @@ The following is an example of code that accomplishes these steps:
 ```{r}
 # Define a vector of paths to the files we wish to load
 file_paths <- c(
-  system.file('extdata', 'ball_berry_1.xlsx', package = 'PhotoGEA'),
-  system.file('extdata', 'ball_berry_2.xlsx', package = 'PhotoGEA')
+  system.file('extdata', 'ball_berry_1.xlsx', package = 'PhotoGEA', mustWork = TRUE),
+  system.file('extdata', 'ball_berry_2.xlsx', package = 'PhotoGEA', mustWork = TRUE)
 )
 
 # Load each file, storing the result in a list


### PR DESCRIPTION
Some users had reported issues when reading files using `read_gasex_file`. After looking in to these issues, it was found that these users were directly copying the example code like
```r
file_paths <- c(
  system.file('extdata', 'ball_berry_1.xlsx', package = 'PhotoGEA'),
  system.file('extdata', 'ball_berry_2.xlsx', package = 'PhotoGEA')
)
```
and replacing `ball_berry_1.xslx` and `ball_berry_2.xlsx` with their own file names.

This had a very confusing and unexpected result. First, `system.file` returned an empty string because it could not find the specified file. Then, `read_gasex_file` interpreted the empty string as if it were a plaintext Licor Li-6800 log file name. Eventually it encountered a problem when calling `read.delim`, and reported an unhelpful error message like `Error in if (skip > 0L) readLines(file, skip) : argument is of length zero`.

This PR addresses this problem in several ways:
- `read_gasex_file` now returns a helpful error message if the `file_name` input is an empty string.
- The examples involving `system.file` now all specify `mustExist = TRUE`. With this option, an error is generated if the file cannot be found, instead of the default behavior of returning an empty string.
- The vignettes now clarify that `system.file` should not be used for loading the user's own files.

Hopefully now users will no longer copy the `system.file` command. If they do, they will probably also copy the `mustExist = TRUE` option, which will cause a more direct error message explaining that the file cannot be found. If a user somehow persists in passing an empty string to `read_gasex_file`, it will also produce a more informative error message.